### PR TITLE
Fixed problem with all response types returning 200 OK

### DIFF
--- a/json-response.js
+++ b/json-response.js
@@ -56,7 +56,7 @@ httpStatus.forEach(function(status) {
         length, nameArr;
 
     var respond = function(data, message) {
-        return this.send(this.response(code, data, message));
+        return this.send(code, this.response(code, data, message));
     };
 
     res[code] = respond;


### PR DESCRIPTION
Currently all the response methods are returning 200 OK (res.internalServerError, res.badRequest) etc.

Passed the code variable into the res.send method to fix it.
